### PR TITLE
Fix network check will failed if the device connected to VPN

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -16,7 +16,7 @@
 #   public *;
 #}
 
--optimizations 5
+#-optimizations 5
 
 -keep class tw.com.louis383.coffeefinder.model.entity.** { *; }
 -keep class tw.com.louis383.coffeefinder.model.domain.** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
 

--- a/app/src/main/java/tw/com/louis383/coffeefinder/model/CoffeeTripAPI.kt
+++ b/app/src/main/java/tw/com/louis383/coffeefinder/model/CoffeeTripAPI.kt
@@ -6,7 +6,6 @@ import okhttp3.MediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
-import retrofit2.converter.gson.GsonConverterFactory
 import tw.com.louis383.coffeefinder.BuildConfig
 import tw.com.louis383.coffeefinder.utils.Utils
 import java.util.concurrent.TimeUnit

--- a/app/src/main/java/tw/com/louis383/coffeefinder/model/ConnectivityChecker.kt
+++ b/app/src/main/java/tw/com/louis383/coffeefinder/model/ConnectivityChecker.kt
@@ -3,11 +3,16 @@ package tw.com.louis383.coffeefinder.model
 import android.content.Context
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.net.wifi.WifiManager
 
 class ConnectivityChecker(context: Context) {
 
     private val connectivityManager by lazy {
-        context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    }
+
+    private val wifiManager by lazy {
+        context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
     }
 
     fun isNetworkAvailable(): Boolean {
@@ -15,6 +20,15 @@ class ConnectivityChecker(context: Context) {
         val networkCapabilities = connectivityManager.getNetworkCapabilities(activeNetwork)
         val isCellularAvailable = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ?: false
         val isWiFiAvailable = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ?: false
-        return isCellularAvailable || isWiFiAvailable
+        // There is a bug which is network capability will return false if a device connected to VPN.
+        // It's often happened in Samsung devices such as Galaxy S8/Note8
+        val isVpnEnabled = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) ?: false
+        val isNormalNetworkAvailable = (isCellularAvailable || isWiFiAvailable)
+        val isVpnNetworkAvailable = (isVpnEnabled && isWiFiEnabledExactly())
+        return isNormalNetworkAvailable || isVpnNetworkAvailable
+    }
+
+    private fun isWiFiEnabledExactly(): Boolean {
+        return wifiManager.isWifiEnabled
     }
 }


### PR DESCRIPTION
  - This is a workaround to fix the issue.
  ConnectivityManager will return false if check the network capability when
  devices connected on VPN. However, this only happen on Samsung devices.